### PR TITLE
applied env variables for provision s3 in  main.tf

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -38,8 +38,9 @@ jobs:
   - name: Initialize Terraform
     run: terraform init
      
+  # Updated to use the environment variables for both plan and apply
   - name: Terraform Plan
     run: terraform plan -var-file="environment/${{ github.event.inputs.environment }}.tfvars"
 
   - name: Terraform Apply
-    run: terraform apply --auto-approve
+    run: terraform apply -var-file="environment/${{ github.event.inputs.environment }}.tfvars" --auto-approve

--- a/README.md
+++ b/README.md
@@ -1,6 +1,27 @@
 ### Objectives:
-1. Using public terraform modules to deploy s3 bucket(s)
+1. Using public terraform modules to deploy s3 bucket(s) - (main)
+    - Runs on initial **`[main]`** branch 
+    - deploys without considering `dev` | `prod` | `staging`
 2. Using environment variables to define the dev, staging or production
-    - Refer to additions in `environment folder` (dev.tfvars, prod.tfvars, staging.tfvars)
+    - Runs on **`[env-variables]`** branch
+    - Refer to additions in `environment` folder (dev.tfvars, prod.tfvars, staging.tfvars)
     - Refer to addition `variables.tf`
     - Refer to updates to CD.yml where the environment profile is added to terraform plan
+    - **Note:** This version still HAVE NOT ADOPTED env variable to deploy between `dev` | `prod` | `staging`
+3. Applying environment variables to deploy between dev, staging or production
+    - Runs on **`[cicd-updated-use-env-vars]`** branch
+    - Updated `CD.yml` in folder `.github/workflows` to use the environment variables plan and apply
+    - Updated `main.tf` to adopt the env variable "name_prefix" to update the environment to deploy (see code block below)
+
+```
+module "s3_bucket" {
+    # Use a terraform public module
+    source = "terraform-aws-modules/s3-bucket/aws" 
+
+    # Provision a Bucket based on the chosen variable name_prefix
+    bucket = "martin20sep2023-${var.name_prefix}-s3-public-mod-bucket"  
+    versioning = {
+        enabled = true
+    }
+}
+```

--- a/backend.tf
+++ b/backend.tf
@@ -1,7 +1,7 @@
 terraform {
   backend "s3" {
     bucket = "martin-cicd-state-bucket"
-    key    = "martin17sep2023-s3-public-mod.tfstate"
+    key    = "martin20sep2023-s3-public-mod.tfstate"
     region = "us-east-1"
   }
 }

--- a/main.tf
+++ b/main.tf
@@ -2,7 +2,7 @@ module "s3_bucket" {
   source = "terraform-aws-modules/s3-bucket/aws"    # Use a terraform public module
 
 
-  bucket = "martin17sep2023-s3-public-mod-bucket"  # Provision a Bucket with versioning
+  bucket = "martin20sep2023-${var.name_prefix}-s3-public-mod-bucket"  # Provision a Bucket with versioning
   versioning = {
     enabled = true
   }


### PR DESCRIPTION
Updated **main.tf** where environment variable **name_prefix** is used to set the deployment choice between dev | staging | prod environments. Also updated **.github/workflows/CD.yml** to use the variables in the `environment` folder to plan and apply the deployment.